### PR TITLE
Add handling for pre tags

### DIFF
--- a/src/epub.rs
+++ b/src/epub.rs
@@ -227,13 +227,20 @@ fn render(n: Node, c: &mut Chapter) {
         }
         "pre" => {
             c.text.push('\n');
-            for child in n.children() {
-                match child.text() {
-                    Some(pretext) => {
-                        let indent = format!("\t{}", pretext);
-                        c.text.push_str(&indent);
+            c.text.push_str("  ");
+            for child in n.descendants() {
+                if child.is_text() {
+                    match child.text() {
+                        Some(text) => {
+                            for char in text.chars() {
+                                c.text.push(char);
+                                if char == '\n' {
+                                    c.text.push_str("  ");
+                                }
+                            }
+                        }
+                        None => {}
                     }
-                    None => {}
                 }
             }
             c.text.push('\n');


### PR DESCRIPTION
Previously, `<pre>` tags in an epub were falling through to the default case and just being rendered as text, which was stringing all the individual lines together into a mess. 

As an example, this is a code snippet from ["Rust in Action"][ria]:

![2021-10-20_224714](https://user-images.githubusercontent.com/6124793/138203394-62ac0d9a-de59-4b05-b315-3e590e824cf8.png)

This PR adds another arm to handle `<pre>` by rendered each line of text individually, adding a single line of whitespace above and below the whole block, along a tab character at the start of each line for indentation. 

Here's the same snippet from above, with the new arm:

![2021-10-20_224602](https://user-images.githubusercontent.com/6124793/138203575-ffccf998-48f4-4fd7-acac-4e739b5ff465.png)

I have not tested this extensively with other sources, but I'm happy to do additional QA work if necessary. I did see that it can lead to some odd text wrapping in cases where a `<pre>` block contains longer lines, as is this other snippet:

![2021-10-20_225942](https://user-images.githubusercontent.com/6124793/138203970-17b7550c-4c73-4f63-9882-600c0a223bb6.png)

This may actually be the expected behavior for the tag, but if that's not appropriate here we can look at some other options.

[ria]: https://www.manning.com/books/rust-in-action