### PR TITLE
fix: create config dir if not exists

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -419,6 +419,7 @@ fn main() {
         .insert(state.path.clone(), (bk.chapter, byte));
     state.save.last = state.path;
     let serialized = ron::to_string(&state.save).unwrap();
+    fs::create_dir_all(state.save_path.split_at(state.save_path.len() - 2).0).ok();
     fs::write(state.save_path, serialized).unwrap_or_else(|e| {
         println!("error saving state: {}", e);
         exit(1);


### PR DESCRIPTION
I have my system reinstalled recently, but when I try to use `bk`, the reading progress cannot be saved due to the lack of directory"~/.local/share". The error log is `error saving state: No such file or directory (os error 2)`.

So maybe `bk` needs to create the "share" dir before saveing the reading progress file.