### PR TITLE
Support Windows-style container.xml file path and allow chapter failed to be parsed

### DIFF
--- a/src/epub.rs
+++ b/src/epub.rs
@@ -54,7 +54,7 @@ impl Epub {
             // UnknownEntityReference for HTML entities
             let xml = self.get_text(&format!("{}{}", self.rootdir, path)).unwrap();
             let opt = ParsingOptions { allow_dtd: true };
-            let doc = Document::parse_with_options(&xml, opt).unwrap();
+            let Ok(doc) = Document::parse_with_options(&xml, opt) else { continue; };
             let body = doc.root_element().last_element_child().unwrap();
             let state = Attributes::default();
             let mut c = Chapter {


### PR DESCRIPTION
Hi, I have an epub file which can be opened in other application like FBReader, but bk crashed when open it.

(You can get the epub file at: http://www.mediafire.com/download/ff5jqt6w83v1dca/Thon+Phe+Tinh+Khong+-+Nga+Cat+Tay+Hong+Thi.epub)

```
$ bk Thon\ Phe\ Tinh\ Khong\ -\ Nga\ Cat\ Tay\ Hong\ Thi.epub 
thread 'main' panicked at src/epub.rs:49:14:
called `Result::unwrap()` on an `Err` value: FileNotFound
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Reason:
1. This epub file has Windows-style path: `META-INF\container.xml` instead of `META-INF/container.xml`.
2. Some chapters are failed to be parsed. Issue may come from `roxmltree`.

Fix:
1. Try to read `META-INF\container.xml` if file `META-INF/container.xml` does not exist.
2. Although issue may come from `romlxtree`, `bk` can just simply ignore fault chapter, and continue to parse other chapters.